### PR TITLE
[DJS-BOT] - Pass Env from host to container

### DIFF
--- a/djs-bot/.env.example
+++ b/djs-bot/.env.example
@@ -4,10 +4,10 @@
 
 # Discord configuration
 
-TOKEN=abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890
-CLIENTID=0123456789012345678
-CLIENTSECRET=abcdefghijklmnopqrstuvwxyz123456
-DEVUID=012345678901234567
+TOKEN=
+CLIENTID=
+CLIENTSECRET=
+DEVUID=
 
 # This was inserted by `prisma init`:
 # Environment variables declared in this file are automatically made available to Prisma.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     container_name: djs-bot
     image: node:latest
     restart: "unless-stopped"
+    environment:
+      - TOKEN=${TOKEN}
+      - CLIENTID=${CLIENTID}
+      - CLIENTSECRET=${CLIENTSECRET}
+      - DEVUID=${DEVUID}
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:
This would allow to configure secrets like Token and Client secret in deployment service like Gitpod through environment variable settings.

Note: For some reason I've to blank out example value in `.env.example`

## Status and versioning classification:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)