### PR TITLE
feat/songcard-progressbar

### DIFF
--- a/djs-bot/commands/music/nowplaying.js
+++ b/djs-bot/commands/music/nowplaying.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder, escapeMarkdown, AttachmentBuilder } = require("discord.js");
 const SlashCommand = require("../../lib/SlashCommand");
-const prettyMilliseconds = require("pretty-ms");
 const createCard = require("songcard");
 const path = require("path");
 
@@ -56,7 +55,8 @@ const command = new SlashCommand()
 			(imageBg = song.displayThumbnail("maxresdefault") || noBgURL),
 			(imageText = song.title),
 			(trackStream = song.isStream),
-			(trackDuration = song.duration)
+			(trackDuration = player.position),
+			(trackTotalDuration = song.duration)
 		);
 
 		const attachment = new AttachmentBuilder(cardImage, { name: "card.png" });

--- a/djs-bot/package.json
+++ b/djs-bot/package.json
@@ -47,7 +47,7 @@
     "prisma": "^5.2.0",
     "rlyrics": "^2.0.1",
     "shoukaku": "^3.4.0",
-    "songcard": "^1.0.5",
+    "songcard": "^1.0.6",
     "winston": "^3.10.0",
     "youtube-sr": "^4.3.4"
   },

--- a/djs-bot/package.json
+++ b/djs-bot/package.json
@@ -47,7 +47,7 @@
     "prisma": "^5.2.0",
     "rlyrics": "^2.0.1",
     "shoukaku": "^3.4.0",
-    "songcard": "^1.0.2",
+    "songcard": "^1.0.5",
     "winston": "^3.10.0",
     "youtube-sr": "^4.3.4"
   },

--- a/djs-bot/package.json
+++ b/djs-bot/package.json
@@ -47,7 +47,7 @@
     "prisma": "^5.2.0",
     "rlyrics": "^2.0.1",
     "shoukaku": "^3.4.0",
-    "songcard": "^1.0.6",
+    "songcard": "^1.0.7",
     "winston": "^3.10.0",
     "youtube-sr": "^4.3.4"
   },


### PR DESCRIPTION
As in the previous PR(#83) the trackDuration in the songcard shows `0:00`. So in this PR the songcard should now shows the correct trackDuration and i also add a new progressBar to the songcard.

Preview:

![image](https://github.com/wtfnotavailable/Discord-MusicBot/assets/90232327/0300b99b-3192-41c5-8a2d-7090345c63cd)
