### PR TITLE
Fix missing argument in /play and /playlists play

### DIFF
--- a/djs-bot/commands/music/play.js
+++ b/djs-bot/commands/music/play.js
@@ -152,7 +152,7 @@ const command = new SlashCommand()
 		}
 
 		if (res.loadType === "PLAYLIST_LOADED") {
-			addTrack(res.tracks);
+			addTrack(player, res.tracks);
 
 			if (
 				!player.playing &&

--- a/djs-bot/commands/music/playlists/play.js
+++ b/djs-bot/commands/music/playlists/play.js
@@ -113,7 +113,7 @@ async function runPlay(client, interaction, options) {
 
     for (const song of songs) {
         const songSearch = await player.search(song.link, interaction.user.id);
-        addTrack(songSearch.tracks[0]);
+        addTrack(player, songSearch.tracks[0]);
     }
 
     if (channel.type == "GUILD_STAGE_VOICE") {

--- a/djs-bot/package.json
+++ b/djs-bot/package.json
@@ -1,7 +1,7 @@
 {
   "description": "",
   "main": "index.js",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "name": "discord-musicbot",
   "scripts": {
     "guild": "node scripts/guild",


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:
If a user tries to add a playlist with the ``/play`` and ``/playlists play``  command, the addTrack function will only receive one argument(tracks).
The addTrack function takes a player and a tracklist, and adds the tracks to the player.

## Status and versioning classification:

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->