### PR TITLE
Adding support for mediakeys

### DIFF
--- a/dashboard/src/pages/servers/[id]/player.tsx
+++ b/dashboard/src/pages/servers/[id]/player.tsx
@@ -441,6 +441,30 @@ const Player: NextPageWithLayout = () => {
         runNextBack(() => {}, SOCKET_WAIT_RES_TIMEOUT);
     };
 
+    useEffect(() => {
+        if ('mediaSession' in navigator) {
+            navigator.mediaSession.setActionHandler('play', togglePlayPause);
+            navigator.mediaSession.setActionHandler('pause', togglePlayPause);
+            navigator.mediaSession.setActionHandler('previoustrack', handlePrevious);
+            navigator.mediaSession.setActionHandler('nexttrack', handleNext);
+        }
+    }, [togglePlayPause, handlePrevious, handleNext]);
+
+    useEffect(() => {
+        const audioElement = document.getElementById('audio') as HTMLAudioElement;
+    
+        const playAudio = () => {
+          audioElement.loop = true;
+          audioElement.play();
+        };
+    
+        document.body.addEventListener('click', playAudio);
+    
+        return () => {
+          document.body.removeEventListener('click', playAudio);
+        };
+    }, []);
+    
     const spacePP = {
         // literally a space
         comb: [' '],
@@ -507,6 +531,7 @@ const Player: NextPageWithLayout = () => {
 
     return (
         <div className="player-page-container">
+            <audio id="audio" src="https://github.com/anars/blank-audio/raw/master/10-minutes-of-silence.mp3" style={{ display: 'none' }}></audio>
             <div
                 className={classNames(
                     'btn-navbar-toggle-container btn-toggle-container',


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:

This pull request adds support for using Media Keys through MediaSessions, allowing you to control the bot's playback without having the browser window in focus and without using commands. The only downside is that in order to use the mediaSessions API, the page has to play audio. Therefore, I have added an <audio> tag that plays a soundless file as a workaround. I welcome any suggestions for doing this differently

## Status and versioning classification:

- Code changes have been tested against the Discord API

