### PR TITLE
fixed skip.js - fixed a embed error message

### DIFF
--- a/djs-bot/commands/music/skip.js
+++ b/djs-bot/commands/music/skip.js
@@ -43,9 +43,11 @@ const command = new SlashCommand()
 		if (status === 1) {
 			return interaction.reply({
 				embeds: [
-					redEmbed(
-						`There is nothing after [${song.title}](${song.uri}) in the queue.`
-					),
+					new EmbedBuilder()
+						.setColor("Red")
+						.setDescription(
+							`There is nothing after [${song.title}](${song.uri}) in the queue.`
+						),
 				],
 			});
 		}


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:
fixed the message: `There is nothing after [${song.title}](${song.uri}) in the queue.`
now it will send a message if there is only one song playing.

Before:
![image](https://github.com/wtfnotavailable/Discord-MusicBot/assets/22334486/03ee1ca5-0212-4c60-955a-e232735eb9f2)
After:
![image](https://github.com/wtfnotavailable/Discord-MusicBot/assets/22334486/d634b3a7-784e-4363-b78e-89163ac0d7f1)


## Status and versioning classification:

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
-->

# Important.

- Write in camelCase, not snake_case.
- Do not push to master/main without testing your changes first, make a branch
  if you have to.