### PR TITLE
feat/Lavalink V4 Support

### DIFF
--- a/djs-bot/commands/music/play.js
+++ b/djs-bot/commands/music/play.js
@@ -124,7 +124,8 @@ const command = new SlashCommand()
 			await editReplyEmbed(redEmbed({ desc: "No results were found" }));
 		}
 
-		if (res.loadType === "TRACK_LOADED" || res.loadType === "SEARCH_RESULT") {
+		// Support both lavalink v4 and v3.
+		if (res.loadType === "TRACK_LOADED" || res.loadType === "SEARCH_RESULT" || res.loadType === "track" || res.loadType === "search") {
 			player.set("requester", interaction.guild.members.me);
 			addTrack(player, res.tracks[0]);
 
@@ -144,7 +145,7 @@ const command = new SlashCommand()
 			);
 		}
 
-		if (res.loadType === "PLAYLIST_LOADED") {
+		if (res.loadType === "PLAYLIST_LOADED" || res.loadType === "playlist") {
 			player.set("requester", interaction.guild.members.me);
 			addTrack(player, res.tracks);
 

--- a/djs-bot/config.js
+++ b/djs-bot/config.js
@@ -1,6 +1,12 @@
 // Allows for .env files to be imported and used
 require('dotenv').config()
 
+/**
+ * restVersion to use // "v4" or "v3"
+ */
+const restVersion = "v4"; // for default lavalink v4 will be use
+
+
 // exporting the module allows for other files to see all the properties in this file as a single object
 module.exports = {
 	/**
@@ -79,6 +85,7 @@ module.exports = {
 			retryAmount: 15, // for lavalink connection attempts
 			retryDelay: 6000, // Delay between reconnect attempts if connection is lost.
 			secure: false, // if lavalink is running SSL
+			version: restVersion, // whether to use Lavalink v4 or v3
 		},
 		{
 			identifier: "LocalNode", // log id string
@@ -88,6 +95,7 @@ module.exports = {
 			retryAmount: 15, // for lavalink connection attempts
 			retryDelay: 6000, // Delay between reconnect attempts if connection is lost.
 			secure: false, // if lavalink is running SSL
+			version: restVersion, // whether to use Lavalink v4 or v3
 		},
 	],
 

--- a/djs-bot/package-lock.json
+++ b/djs-bot/package-lock.json
@@ -20,7 +20,7 @@
 				"cron": "^2.4.4",
 				"discord.js": "^14.14.1",
 				"dotenv": "^16.4.2",
-				"erela.js": "^2.4.0",
+				"erela.js": "github:Tomato6966/erela.js#main",
 				"erela.js-deezer": "^1.0.7",
 				"express": "^4.18.2",
 				"fastify": "^4.26.0",
@@ -1609,17 +1609,16 @@
 			}
 		},
 		"node_modules/erela.js": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/erela.js/-/erela.js-2.4.0.tgz",
-			"integrity": "sha512-wLfPvfzbDZTDV0zwJYXGkjO9Q6mkXi3PNf984apdv58Ktt0cv1Zp8og3hmp7Ose4C4iwAKitHxV/yiP+pt3FRQ==",
+			"version": "2.3.3",
+			"resolved": "git+ssh://git@github.com/Tomato6966/erela.js.git#b2b2f00bab24b78abb29b39ff199cc502806b78b",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/collection": "^1.1.0",
-				"tslib": "^2.4.0",
-				"undici": "^5.10.0",
-				"ws": "^8.8.1"
+				"tslib": "^2.6.0",
+				"undici": "^5.22.1",
+				"ws": "^8.13.0"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=16.6.0"
 			}
 		},
 		"node_modules/erela.js-deezer": {

--- a/djs-bot/package.json
+++ b/djs-bot/package.json
@@ -35,7 +35,7 @@
 		"cron": "^2.4.4",
 		"discord.js": "^14.14.1",
 		"dotenv": "^16.4.2",
-		"erela.js": "^2.4.0",
+		"erela.js": "github:Tomato6966/erela.js#main",
 		"erela.js-deezer": "^1.0.7",
 		"express": "^4.18.2",
 		"fastify": "^4.26.0",

--- a/djs-bot/util/controlChannelEvents.js
+++ b/djs-bot/util/controlChannelEvents.js
@@ -109,9 +109,11 @@ const handleMessageCreate = async (message) => {
 	const noMatches = searchResult.loadType === "NO_MATCHES";
 	const trackLoaded =
 		searchResult.loadType === "TRACK_LOADED" ||
-		searchResult.loadType === "SEARCH_RESULT";
+		searchResult.loadType === "SEARCH_RESULT" ||
+		searchResult.loadType === "track" ||
+		searchResult.loadType === "search";
 
-	const playlistLoaded = searchResult.loadType === "PLAYLIST_LOADED";
+	const playlistLoaded = searchResult.loadType === "PLAYLIST_LOADED" || searchResult.loadType === "playlist";
 
 	if (loadFailed || noMatches) {
 		playerDestroy();


### PR DESCRIPTION
Since this bot been using old unmaintained wrapper (Erela.js) for a long time i think it would be good to change to a new wrapper. This new repo are unmaintained but at least it still support both lavalink v3 and v4.